### PR TITLE
Added missing test from other test suites

### DIFF
--- a/test/LuniverseGluwacoin.test.js
+++ b/test/LuniverseGluwacoin.test.js
@@ -1473,7 +1473,7 @@ describe('LuniverseGluwacoin_Reservable', function () {
         var nonce = Date.now();
         await expectRevert(
             this.token.reclaim(other, nonce, { from: another }),
-            'ERC20ReseReservablervable: reservation does not exist'
+            'Reservable: reservation does not exist'
         );
     });
 


### PR DESCRIPTION
What's in this PR:
- Added tests on newly-added Gluwa/Luniverse address for mint/approve/ETHless transfer
- Brought over missing reservation tests from ERC20WrapperFunction test suites