### PR TITLE
SC-21: Include git workflow into all the smart contract repos

### DIFF
--- a/.github/workflows/remote.yml
+++ b/.github/workflows/remote.yml
@@ -1,10 +1,10 @@
-name: Run all tests
+name: Run ERC20 basic tests on Kaleido
 
 on:
   workflow_dispatch:
 
 jobs:
-  remote testing:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/remote.yml
+++ b/.github/workflows/remote.yml
@@ -1,0 +1,22 @@
+name: Run all tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  remote testing:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: NPM Clean Install
+        run: npm ci
+      - name: Hardhat Compile
+        run: npx hardhat compile
+      - name: Hardhat Test
+        run: npx hardhat test test/LuniverseGluwacoin.basicERC20.test.js
+        with:
+          args: --network kaleido
+        env:
+          RPC_KALEIDO_USER: ${{ secrets.RPC_KALEIDO_USER }}
+          RPC_KALEIDO_PASS: ${{ secrets.RPC_KALEIDO_PASS }}
+          KALEIDO_PRIVATEKEY: ${{ secrets.KALEIDO_PRIVATEKEY }}


### PR DESCRIPTION
This adds remote testing workflows only available on demand
GitHub secrets need to be added with the Kaleido RPC user and password as well as the private key